### PR TITLE
Make NODE_ENV the right thing during builds

### DIFF
--- a/app-template.yaml
+++ b/app-template.yaml
@@ -6,3 +6,4 @@ env_variables:
   ANVIL_BASE_URL: 'https://app.useanvil.com'
   UI_BASE_URL: 'https://esign-demo.useanvil.com'
   API_BASE_URL: 'https://esign-demo.useanvil.com'
+  NODE_ENV: 'production'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "build": "webpack --mode production",
+    "build": "NODE_ENV=production webpack --mode production",
     "start": "node src/server/index.js",
     "client": "webpack-dev-server --mode development --devtool inline-source-map --hot",
     "server": "nodemon src/server/index.js",


### PR DESCRIPTION
We want to make sure we are using `NODE_ENV=production` for the deployed sample app, so we make sure it is defined when we `yarn build` for webpack to pick up. Also adding it to the app template to exists during runtime so we can use that for any none frontend stuff.