### PR TITLE
Close iframe/modal only on signerComplete and signerError

### DIFF
--- a/src/client/routes/PacketDetailsPage/index.js
+++ b/src/client/routes/PacketDetailsPage/index.js
@@ -98,12 +98,17 @@ const PacketDetailsPage = () => {
 
   const handleIframeEvent = async (eventObject) => {
     // https://www.useanvil.com/docs/api/e-signatures/#events-from-the-iframe
+    const { action } = eventObject
     console.log('Event Payload:', eventObject)
-    setIsSignFrameOpen(false)
-    setIsModalOpen(false)
+
+    if (action === 'signerComplete' || action === 'signerError') {
+      setIsSignFrameOpen(false)
+      setIsModalOpen(false)
+    }
+
     setPacketDetails(await getEtchPacket())
     setQueryStringData(eventObject)
-    setSignerCompleteDataType(eventObject.action)
+    setSignerCompleteDataType(action)
   }
 
   const renderHeader = () => {


### PR DESCRIPTION
iframe and modal were previously closing on all signer events, but with the recently added `signerLoad` event, it was closing right away.

Correctly stays open on `signerLoad`
<img width="660" alt="Screenshot 2024-03-22 at 10 53 58 AM" src="https://github.com/anvilco/anvil-e-signature-api-node-example/assets/4063707/d3ccd840-7787-4dce-962f-da4372f27e72">

Completes and closes on `signerComplete`
<img width="705" alt="Screenshot 2024-03-22 at 10 54 19 AM" src="https://github.com/anvilco/anvil-e-signature-api-node-example/assets/4063707/e1774431-dee3-4080-a8ca-6eddc818499a">
